### PR TITLE
Test `@Enable` annotation bean registration behavior

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     api 'com.github.knittl:ddd-annotations:0.0.1-SNAPSHOT'
 
     implementation 'org.springframework:spring-context:5.+'
+    testImplementation 'org.springframework:spring-test:5.+'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/src/test/java/at/appicenter/ddd/spring/BasePackageTest.java
+++ b/src/test/java/at/appicenter/ddd/spring/BasePackageTest.java
@@ -1,0 +1,31 @@
+package at.appicenter.ddd.spring;
+
+import at.appicenter.ddd.spring.services.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.springframework.beans.factory.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.context.*;
+import org.springframework.context.annotation.*;
+import org.springframework.test.context.*;
+import org.springframework.test.context.junit.jupiter.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = BasePackageTest.Config.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BasePackageTest {
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void beans_must_be_instantiated() {
+        Assertions.assertNotNull(applicationContext.getBean(DummyApplicationService.class));
+        Assertions.assertNotNull(applicationContext.getBean(DummyDomainService.class));
+    }
+
+    @Configuration
+    @EnableApplicationServices(basePackages = "at.appicenter.ddd.spring.services")
+    @EnableDomainServices(basePackageClasses = DummyDomainService.class)
+    public static class Config {
+    }
+}

--- a/src/test/java/at/appicenter/ddd/spring/CustomBeanNameTest.java
+++ b/src/test/java/at/appicenter/ddd/spring/CustomBeanNameTest.java
@@ -1,0 +1,38 @@
+package at.appicenter.ddd.spring;
+
+import at.appicenter.ddd.spring.services.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.springframework.beans.factory.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.context.*;
+import org.springframework.context.annotation.*;
+import org.springframework.test.context.*;
+import org.springframework.test.context.junit.jupiter.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = CustomBeanNameTest.Config.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CustomBeanNameTest {
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void custom_bean_name_must_be_set() {
+        // bean must be found with custom bean name
+        Assertions.assertNotNull(applicationContext.getBean("customApplicationServiceBeanName"));
+    }
+
+    @Test
+    void default_bean_name_must_not_be_set() {
+        // bean must not be found with default/generated bean name
+        Assertions.assertThrows(
+                NoSuchBeanDefinitionException.class,
+                () -> applicationContext.getBean("dummyApplicationService"));
+    }
+
+    @Configuration
+    @EnableApplicationServices
+    public static class Config {
+    }
+}

--- a/src/test/java/at/appicenter/ddd/spring/DomainDrivenApplicationTest.java
+++ b/src/test/java/at/appicenter/ddd/spring/DomainDrivenApplicationTest.java
@@ -1,0 +1,28 @@
+package at.appicenter.ddd.spring;
+
+import at.appicenter.ddd.spring.services.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.context.*;
+import org.springframework.context.annotation.*;
+import org.springframework.test.context.*;
+import org.springframework.test.context.junit.jupiter.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = DomainDrivenApplicationTest.Config.class)
+class DomainDrivenApplicationTest {
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void ddd_services_must_exist_as_bean() {
+        Assertions.assertNotNull(applicationContext.getBean(DummyDomainService.class));
+        Assertions.assertNotNull(applicationContext.getBean(DummyApplicationService.class));
+    }
+
+    @Configuration
+    @DomainDrivenApplication
+    public static class Config {
+    }
+}

--- a/src/test/java/at/appicenter/ddd/spring/EnableApplicationServicesTest.java
+++ b/src/test/java/at/appicenter/ddd/spring/EnableApplicationServicesTest.java
@@ -1,0 +1,38 @@
+package at.appicenter.ddd.spring;
+
+import at.appicenter.ddd.spring.services.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.springframework.beans.factory.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.context.*;
+import org.springframework.context.annotation.*;
+import org.springframework.test.context.*;
+import org.springframework.test.context.junit.jupiter.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = EnableApplicationServicesTest.Config.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EnableApplicationServicesTest {
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void application_services_must_exist_as_bean() {
+        // only application service beans should be instantiated
+        Assertions.assertNotNull(applicationContext.getBean(DummyApplicationService.class));
+    }
+
+    @Test
+    void domain_services_must_not_exist_as_bean() {
+        // only application service beans should be instantiated
+        Assertions.assertThrows(
+                NoSuchBeanDefinitionException.class,
+                () -> applicationContext.getBean(DummyDomainService.class));
+    }
+
+    @Configuration
+    @EnableApplicationServices
+    public static class Config {
+    }
+}

--- a/src/test/java/at/appicenter/ddd/spring/EnableDomainServicesTest.java
+++ b/src/test/java/at/appicenter/ddd/spring/EnableDomainServicesTest.java
@@ -1,0 +1,38 @@
+package at.appicenter.ddd.spring;
+
+import at.appicenter.ddd.spring.services.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.springframework.beans.factory.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.context.*;
+import org.springframework.context.annotation.*;
+import org.springframework.test.context.*;
+import org.springframework.test.context.junit.jupiter.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = EnableDomainServicesTest.Config.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EnableDomainServicesTest {
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void domain_services_must_exist_as_bean() {
+        // only domain service beans should be instantiated
+        Assertions.assertNotNull(applicationContext.getBean(DummyDomainService.class));
+    }
+
+    @Test
+    void application_services_must_not_exist_as_bean() {
+        // only domain service beans should be instantiated
+        Assertions.assertThrows(
+                NoSuchBeanDefinitionException.class,
+                () -> applicationContext.getBean(DummyApplicationService.class));
+    }
+
+    @Configuration
+    @EnableDomainServices
+    public static class Config {
+    }
+}

--- a/src/test/java/at/appicenter/ddd/spring/services/DummyApplicationService.java
+++ b/src/test/java/at/appicenter/ddd/spring/services/DummyApplicationService.java
@@ -1,0 +1,9 @@
+package at.appicenter.ddd.spring.services;
+
+import at.appicenter.ddd.annotations.*;
+import org.springframework.stereotype.*;
+
+@ApplicationService
+@Component("customApplicationServiceBeanName")
+public class DummyApplicationService {
+}

--- a/src/test/java/at/appicenter/ddd/spring/services/DummyDomainService.java
+++ b/src/test/java/at/appicenter/ddd/spring/services/DummyDomainService.java
@@ -1,0 +1,7 @@
+package at.appicenter.ddd.spring.services;
+
+import at.appicenter.ddd.annotations.DomainService;
+
+@DomainService
+public class DummyDomainService {
+}


### PR DESCRIPTION
Add automated Spring tests to verify proper behavior of bean
registration being performed for applications with `@Enable*`
annotations in their configuration.

Several cases are covered:

* Single annotations
* Mixed/multiple annotations
* Meta-annotation (`@DomainDrivenApplication`)
* Custom component name
* Base package scanning

Fixes #1